### PR TITLE
Fixed search URL to use RTD rather than default Sphinx one

### DIFF
--- a/_themes/bootstrap/searchbox.html
+++ b/_themes/bootstrap/searchbox.html
@@ -2,7 +2,5 @@
 <form class="pull-left" action="http://readthedocs.org/search/project" method="get">
   <input type="text" name="q" placeholder="Search Documentation" />
   <input type="hidden" name="selected_facets" value="project:Astropy" />
-  <input type="hidden" name="check_keywords" value="yes" />
-  <input type="hidden" name="area" value="default" />
 </form>
 {%- endif %}

--- a/_themes/bootstrap/searchbox.html
+++ b/_themes/bootstrap/searchbox.html
@@ -1,6 +1,7 @@
 {%- if pagename != "search" %}
-<form class="pull-left" action="http://astropy.readthedocs.org/en/latest/search.html" method="get">
+<form class="pull-left" action="http://readthedocs.org/search/project" method="get">
   <input type="text" name="q" placeholder="Search Documentation" />
+  <input type="hidden" name="selected_facets" value="project:Astropy" />
   <input type="hidden" name="check_keywords" value="yes" />
   <input type="hidden" name="area" value="default" />
 </form>


### PR DESCRIPTION
The search wasn't working nicely before because I was using the default sphinx one:

http://astropy.readthedocs.org/en/latest/search.html?q=FITS&check_keywords=yes&area=default

rather than the RTD one:

http://readthedocs.org/search/project/?q=FITS&selected_facets=project%3AAstropy

which seems more robust for multiple keywords. I will merge this later today if there are no objections.
