### PR TITLE
Added initial version of affiliated package repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ clean:
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	test -d $(BUILDDIR)/html/affiliated || mkdir -p $(BUILDDIR)/html/affiliated
+	cp affiliated/registry.json $(BUILDDIR)/html/affiliated/registry.json
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1,0 +1,32 @@
+{
+    "packages": [
+        {
+            "name": "specutils",
+            "maintainer": "Wolfgang Kerzendorf",
+            "stable": false,
+            "home_url": "https://github.com/astropy/specutils",
+            "repo_url": "http://github.com/astropy/specutils.git",
+        },
+        {
+            "name": "pyidlastro",
+            "maintainer": "Tom Aldcroft",
+            "stable": false,
+            "home_url": "https://github.com/astropy/pyidlastro",
+            "repo_url": "http://github.com/astropy/pyidlastro.git",
+        },
+        {
+            "name": "photutils",
+            "maintainer": "Rene Breton",
+            "stable": false,
+            "home_url": "https://github.com/astropy/photutils",
+            "repo_url": "http://github.com/astropy/photutils.git",
+        }
+        {
+            "name": "kcorrect",
+            "maintainer": "Taro Sato",
+            "stable": false,
+            "home_url": "https://github.com/astropy/kcorrect",
+            "repo_url": "http://github.com/astropy/kcorrect.git",
+        }
+    ]
+}

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -34,7 +34,6 @@
             "stable": true,
             "home_url": "http://packages.python.org/Astropysics/",
             "repo_url": "http://github.com/eteq/astropysics.git",
-            "tarfile_url": "http://pypi.python.org/packages/source/A/Astropysics/Astropysics-0.1.dev-r1161.tar.gz",
             "pypi_name": "astropysics"
         }
     ]

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -28,5 +28,14 @@
             "home_url": "https://github.com/astropy/kcorrect",
             "repo_url": "http://github.com/astropy/kcorrect.git",
         }
+        {
+            "name": "astropysics",
+            "maintainer": "Erik Tollerud",
+            "stable": true,
+            "home_url": "http://packages.python.org/Astropysics/",
+            "repo_url": "http://github.com/eteq/astropysics.git",
+            "tarfile_url": "http://pypi.python.org/packages/source/A/Astropysics/Astropysics-0.1.dev-r1161.tar.gz",
+            "pypi_name": "astropysics"
+        }
     ]
 }


### PR DESCRIPTION
This is the initial version of the affiliated package registry. When the sphinx docs are built, this will be placed in http://www.astropy.org/affiliated/registry.json, and we can get affiliated.astropy.org to point to astropy.org/affiliated.
