### PR TITLE
Use rsync instead of cp to ensure that files that are removed from the source are deleted from the build

### DIFF
--- a/upload_script.py
+++ b/upload_script.py
@@ -129,7 +129,7 @@ def copy_html_to_page_repo(repodir):
     
     #copy file
     if continue_check('Copy contents of {0} to {1}?'.format(htmldir, repodir)):
-        syscall = 'cp -r {0} {1}'.format(path.join(htmldir, '*'), repodir)
+        syscall = 'rsync -a --update --delete {0} {1}'.format(path.join(htmldir, '*'), repodir)
         safe_syscall(syscall)
 
 

--- a/upload_script.py
+++ b/upload_script.py
@@ -129,7 +129,7 @@ def copy_html_to_page_repo(repodir):
     
     #copy file
     if continue_check('Copy contents of {0} to {1}?'.format(htmldir, repodir)):
-        syscall = 'rsync -a --update --delete {0} {1}'.format(path.join(htmldir, '*'), repodir)
+        syscall = 'rsync -a --delete {0} {1}'.format(path.join(htmldir, '*'), repodir)
         safe_syscall(syscall)
 
 


### PR DESCRIPTION
I noticed with the most recent changes that this script was using `cp`, so files removed from the source are not removed from the build. This should fix it - do you agree?
