### PR TITLE
Update "The Team" link to pull from astropy repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build
+*.pyc

--- a/conf.py
+++ b/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['replaceteam']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/replaceteam.py
+++ b/replaceteam.py
@@ -1,0 +1,71 @@
+"""
+A sphinx extension that replaces the ``team.rst`` file with the credits file
+from the astropy repository.
+
+Note that this first looks for the ``ASTROPY_REPO_PATH`` environment
+variable to try to find a local copy of the astropy repo.
+"""
+
+
+def setup(app):
+    app.connect('source-read', replace_team)
+
+
+def replace_team(app, docname, source):
+    if docname == 'team':
+
+        credits = get_astropy_credits(app.warn).decode('utf-8')
+
+        if credits is not False:
+            creditslines = credits.split('\n')
+
+            newcreditslines = []
+            for l in creditslines:
+                # replace section headings with the correct type of heading for web site
+                if l.startswith('==='):
+                    l = l.replace('=', '-')
+                newcreditslines.append(l)
+
+            #replace the title block
+            newcreditslines[0] = ''
+            newcreditslines[1] = 'The Astropy Team'
+            newcreditslines[2] = '================'
+
+            #add the orphan marker
+            newcreditslines.insert(0, ':orphan:')
+
+            # now actually use the new source - this is what sphinx processes
+            source[0] = '\n'.join(newcreditslines)
+            print source
+
+
+def get_astropy_credits(warner):
+    """
+    Looks for the ``credits.rst`` file in the astropy repo and returns it, or
+    returns False if the repo can't be found.
+    """
+    import os
+    from urllib2 import urlopen
+
+    creditspath = os.environ.get('ASTROPY_REPO_PATH',
+        'http://raw.github.com/astropy/astropy/master/docs/credits.rst')
+
+    if creditspath.startswith('http'):
+        #url - download page from web
+        u = None
+        try:
+            u = urlopen(creditspath)
+            return u.read()
+        except Exception as e:
+            warner('Could not download credits.rst from requested path: "{0}" Using placeholder for "The Team" page.'.format(e))
+            return False
+        finally:
+            if u is not None:
+                u.close()
+    else:
+        if not os.path.isfile(creditspath):
+            warner('Credits.rst file at "{0}" is not a file! Using placeholder for "The Team" page.'.format(creditspath))
+            return False
+
+        with open(creditspath) as f:
+            return f.read()

--- a/replaceteam.py
+++ b/replaceteam.py
@@ -36,7 +36,6 @@ def replace_team(app, docname, source):
 
             # now actually use the new source - this is what sphinx processes
             source[0] = '\n'.join(newcreditslines)
-            print source
 
 
 def get_astropy_credits(warner):

--- a/team.rst
+++ b/team.rst
@@ -1,52 +1,16 @@
 :orphan:
 
-The Astropy team
-----------------
+The Astropy Team 
+================
 
-.. _`astropy-dev`: http://groups.google.com/group/astropy-dev
-.. _`specutils`: https://github.com/astropy/specutils
-.. _`pyidlastro`: https://github.com/astropy/pyidlastro
-.. _`photutils`: https://github.com/astropy/photutils
-.. _`kcorrect`: https://github.com/astropy/kcorrect
+.. warning::
+	If the web site builds correctly, this page should get replaced and the
+	text below should never appear.
 
-Project Coordinators
-^^^^^^^^^^^^^^^^^^^^
-
-* Perry Greenfield, STScI
-* `Thomas Robitaille <http://www.mpia.de/~robitaille/>`_, MPIA
-* `Erik Tollerud <http://www.physics.uci.edu/~etolleru/>`_, UC Irvine
-
-Core package maintainers
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-In addition to the coordination committee, the following individuals maintain the core package:
-
-* `Tom Aldcroft <http://hea-www.harvard.edu/~aldcroft/>`_, CfA
-* Erik Bray, STScI
-* Matt Davis, STScI
-* `Michael Droettboom <http://droettboom.com>`_, STScI
-
-Affiliated package maintainers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* `Tom Aldcroft <http://hea-www.harvard.edu/~aldcroft/>`_, CfA (`pyidlastro`_)
-* Rene Breton, University of Southampton (`photutils`_)
-* Wolfgang Kerzendorf, ANU (`specutils`_)
-* Taro Sato (`kcorrect`_)
-
-Contributors
-^^^^^^^^^^^^
-
-* Demitri Muna, NYU
-* `Adrian Price-Whelan <http://www.adrianpricewhelan.com/>`_, Columbia U
-* `Steve Crawford <http://www.salt.ac.za/about/people-partners/operations-team/steve-crawford/>`_, SALT
-* `Adam Ginsburg <http://casa.colorado.edu/~ginsbura/>`_, U Colorado
-* Frederic Grollier
-* Prasanth Nair
-* `Neil Crighton <http://www.mpia.de/~nhmc/>`_, MPIA
-* Christoph Deil, MPIK
-* `Kyle Barbary <http://sites.google.com/site/kylebarbary/>`_, Lawrence Berkeley National Lab, 
-
-... and thanks to everyone on the `astropy-dev`_ mailing list for contributing to many discussions and decisions!
-
-(If you have contribute to the Astropy project, and your name is missing, please send an email to the coordinators, or open a pull request `here <https://github.com/astropy/astropy-website>`_!)
+This is a placeholder for the Astropy author list.  In the build process
+for the site, this will be replaced by a copy taken from the Astropy
+core package repository.  If you're seeing this page, it means that 
+download process failed somehow.  If you're not connected to the
+internet but have a local copy of astropy, you can try setting the
+``ASTROPY_REPO_PATH`` environment variable to point to the
+repository.


### PR DESCRIPTION
This PR implements the approach discussed in #19 - the "The Team" page is now pulled from the astropy repo so we don't have to keep it up to date here separately.  You can see the result at http://eteq.github.com/astropy-website/ (or http://eteq.github.com/astropy-website/team.html for the author list page)
