### PR TITLE
Added docs page

### DIFF
--- a/_themes/bootstrap/menubar.html
+++ b/_themes/bootstrap/menubar.html
@@ -1,4 +1,4 @@
-<li><a href="http://astropy.readthedocs.org" rel="nofollow">{{ _('Documentation') }}</a></li>
+<li><a href="docs.html" rel="nofollow">{{ _('Documentation') }}</a></li>
 <li><a href="contributing.html" rel="nofollow">{{ _('Contributing') }}</a></li>
 <li><a href="team.html" rel="nofollow">{{ _('The Team') }}</a></li>
 

--- a/docs.rst
+++ b/docs.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+Astropy Documentation
+=====================
+
+Below are links to the documentation for all versions of Astropy.
+
+* `Latest developer version <http://devdocs.astropy.org>`_ 
+* `v0.2 (Current Stable Version) <https://astropy.readthedocs.org/en/v0.2/index.html>`_
+* `v0.1 <https://astropy.readthedocs.org/en/v0.1/index.html>`_

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,3 @@
-.. title:: Welcome
-
 .. _`PyFITS`: http://www.stsci.edu/institute/software_hardware/pyfits
 .. _`PyWCS`: https://trac.assembla.com/astrolib
 .. _`vo`: https://trac.assembla.com/astrolib
@@ -56,6 +54,8 @@ automatically updated any time a change is made to the
 
 * `Stable version (docs.astropy.org) <http://docs.astropy.org>`_
 * `Latest developer version (devdocs.astropy.org) <http://devdocs.astropy.org>`_ 
+
+A full list of archived documentation can be found at :doc:`docs`.
     
 
 


### PR DESCRIPTION
Currently the astropy web site "Documentation" link goes straight to the latest docs.  With the impending 0.2 release, it would be worthwhile to have a page listing all the released versions of astropy documentation.  This also makes the top menu bar more consistent in that clicking on one of those links doesn't send you out of the astropy.org page.

The link to "current stable" and "latest developer" is still present on the front page though, so the latest docs remain one click away.

This probably should not be merged until 0.2 is out, though, as I added the relevant link to make the intended layout clear, and we don't want to confuse people by having it present when the release isn't done yet.
