### PR TITLE
Update instructions on pulling developer version

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -81,7 +81,7 @@ If you do not get any errors, the installation was successful!
 
     If you want to install the latest *developer* version of Astropy, use::
 
-        git clone http://github.com/astropy/astropy.git
+        git clone https://github.com/astropy/astropy.git
         cd astropy
         python setup.py install
 


### PR DESCRIPTION
Github blocks (at least from my machine) all http connetions, instead https should be used.
