### PR TITLE
fix affiliated.astropy.org menubar

### DIFF
--- a/_themes/bootstrap/menubar.html
+++ b/_themes/bootstrap/menubar.html
@@ -1,4 +1,4 @@
-<li><a href="docs.html" rel="nofollow">{{ _('Documentation') }}</a></li>
-<li><a href="contributing.html" rel="nofollow">{{ _('Contributing') }}</a></li>
-<li><a href="team.html" rel="nofollow">{{ _('The Team') }}</a></li>
+<li><a href="{{ pathto('docs.html',1) }}" rel="nofollow">{{ _('Documentation') }}</a></li>
+<li><a href="{{ pathto('contributing.html',1) }}" rel="nofollow">{{ _('Contributing') }}</a></li>
+<li><a href="{{ pathto('team.html',1) }}" rel="nofollow">{{ _('The Team') }}</a></li>
 


### PR DESCRIPTION
The affilated/index.html menubar for affiliated.astropy.org  was broken because it points to `http://www.astropy.org/affiliated/*` instead of `http://www.astropy.org/*` as it's supposed to.  This change fixes it by using sphinxs templating features to figure out the correct path.

Obviously I haven't tested it on the live web site, but it works for me locally.
