### PR TITLE
Added APLpy to affiliated packages

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -67,6 +67,14 @@
             "stable": false,
             "home_url": "https://github.com/weaverba137/pydl",
             "repo_url": "http://github.com/weaverba137/pydl.git"
+        },
+        {
+            "name": "APLpy",
+            "maintainer": "Thomas Robitaille and Eli Bressert <astropython@gmail.com>",
+            "stable": true,
+            "home_url": "https://aplpy.github.io",
+            "repo_url": "http://github.com/aplpy/aplpy.git",
+            "pypi_name": "aplpy"
         }
     ]
 }


### PR DESCRIPTION
APLpy 0.9.9 is now out and fully relies on Astropy. It also now includes tests, so I think it can be considered an affiliated package :)
