### PR TITLE
Move the link with all the versions to the front page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -56,9 +56,8 @@ automatically updated any time a change is made to the
 `astropy source code repository <http://github.com/astropy/astropy>`_.
 
 * `Stable version (docs.astropy.org) <http://docs.astropy.org>`_
-* `Latest developer version (devdocs.astropy.org) <http://devdocs.astropy.org>`_ 
-
-A full list of archived documentation can be found at :doc:`docs`.
+* `Latest developer version (devdocs.astropy.org) <http://devdocs.astropy.org>`_
+* :doc:`All versions <docs>`
     
 
 


### PR DESCRIPTION
As suggested by @taldcroft in astropy/astropy#1079 , this moves the link to the page listing all the versions to the bullet-pointed list on the front page instead of the paragraph below.  (See http://eteq.github.io/astropy-website vs http://www.astropy.org)
