### PR TITLE
add menu link to affiliated page

### DIFF
--- a/_themes/bootstrap/menubar.html
+++ b/_themes/bootstrap/menubar.html
@@ -1,4 +1,4 @@
 <li><a href="{{ pathto('docs.html',1) }}" rel="nofollow">{{ _('Documentation') }}</a></li>
 <li><a href="{{ pathto('contributing.html',1) }}" rel="nofollow">{{ _('Contributing') }}</a></li>
 <li><a href="{{ pathto('team.html',1) }}" rel="nofollow">{{ _('The Team') }}</a></li>
-
+<li><a href="{{ pathto('affiliated/index.html',1) }}" rel="nofollow">{{ _('Affiliated') }}</a></li>

--- a/_themes/bootstrap/searchbox.html
+++ b/_themes/bootstrap/searchbox.html
@@ -1,5 +1,5 @@
 {%- if pagename != "search" %}
-<form class="pull-left" action="http://docs.astropy.org/en/stable/search.html" method="get">
+<form class="pull-right" action="http://docs.astropy.org/en/stable/search.html" method="get">
   <input type="text" name="q" placeholder="Search Documentation" />
   <input type="hidden" name="check_keywords" value="yes" />
   <input type="hidden" name="area" value="default" />

--- a/_themes/bootstrap/static/bootstrap.css
+++ b/_themes/bootstrap/static/bootstrap.css
@@ -262,12 +262,12 @@ a:hover {
 }
 .pull-right {
   float: right;
-  width: 280px;
+  width: 240px;
   text-align: right;
 }
 .pull-left {
   float: left;
-  width: 280px;
+  width: 240px;
   text-align: left;
 }
 .hide {


### PR DESCRIPTION
The affiliated package page is getting more and more important with a growing number of useful affiliated packages. Yet, I find it very difficult to locate this page.

This PR adds a menubar link to the affiliated package page. See a built preview here:
http://kbarbary.github.io/astropy-website/
