### PR TITLE
explicitly stated that we follow the PSF code of conduct

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -35,3 +35,8 @@ other developers of your intent to develop an affiliated package, you can head
 over `here <https://github.com/astropy/package-template>`_ for instructions on
 getting started! We can even create a repository for your affiliated package
 in the `astropy` organization on GitHub!
+
+Community
+---------
+Astropy welcomes anyone who wants to contribute to the project. We follow the 
+`Python Software Foundation Code of Conduct <http://www.python.org/psf/codeofconduct/>`_.


### PR DESCRIPTION
Added this little note in regards to astropy issue 1216. I'm not super-happy with the wording, so feel free to other complete re-writes.
