### PR TITLE
Update docs to show link to 0.2.4

### DIFF
--- a/docs.rst
+++ b/docs.rst
@@ -6,7 +6,8 @@ Astropy Documentation
 Below are links to the documentation for all versions of Astropy.
 
 * `Latest developer version <http://devdocs.astropy.org>`_ 
-* `v0.2.3 (Current Stable Version) <https://astropy.readthedocs.org/en/v0.2.3/index.html>`_
+* `v0.2.4 (Current Stable Version) <https://astropy.readthedocs.org/en/v0.2.4/index.html>`_
+* `v0.2.3 <https://astropy.readthedocs.org/en/v0.2.3/index.html>`_
 * `v0.2.2 <https://astropy.readthedocs.org/en/v0.2.2/index.html>`_
 * `v0.2.1 <https://astropy.readthedocs.org/en/v0.2.1/index.html>`_
 * `v0.2 <https://astropy.readthedocs.org/en/v0.2/index.html>`_


### PR DESCRIPTION
IU have made this PR in the astropy.github.com repository. But @astrofrog mentioned that I should do this here. So here it is. 

https://github.com/astropy/astropy.github.com/pull/1
