### PR TITLE
Add gammapy to affiliated package registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -76,6 +76,14 @@
             "home_url": "http://aplpy.github.io",
             "repo_url": "http://github.com/aplpy/aplpy.git",
             "pypi_name": "APLpy"
+        },
+        {
+            "name": "gammapy",
+            "maintainer": "Christoph Deil <Deil.Christoph@gmail.com>",
+            "stable": false,
+            "home_url": "https://github.com/gammapy/gammapy",
+            "repo_url": "http://github.com/gammapy/gammapy.git"
+            "pypi_name": "gammapy"
         }
     ]
 }


### PR DESCRIPTION
I've also asked for this package to be accepted as an astropy affiliated package here:
https://groups.google.com/forum/#!topic/astropy-dev/O5h6HGnISI8

Please let me know if there's anything else I should before gammapy can be accepted as an affiliated package.
